### PR TITLE
Fixed description of upper boundary conditions for katabatic experiments

### DIFF
--- a/microhharticle.tex
+++ b/microhharticle.tex
@@ -625,7 +625,7 @@ u_{n} =\sqrt{2} \sin (z_{n} /\sqrt{2} )\exp (-z_{n} /\sqrt{2} ),\\b_{n} =\sqrt{2
   \item Initial condition: stratified fluid at rest above the slope with zero surface buoyancy flux
   \item Lateral boundary conditions: periodic
   \item Lower boundary conditions: no-slip and impermeability conditions for velocity, surface-flux condition for buoyancy
-  \item Upper boundary conditions: no-slip and impermeability conditions for velocity, zero-flux condition for buoyancy
+  \item Upper boundary conditions: free-slip conditions for velocity, zero-gradient condition for buoyancy
 \end{itemize}
 \subsection{Flow description and simulation results}
 
@@ -713,7 +713,7 @@ Flux profiles shown in Fig.~\ref{katabatic_wu} and Fig.~\ref{katabatic_wb} indic
   \item Initial condition: stratified fluid at rest above the slope with zero surface buoyancy flux
   \item Lateral boundary conditions: periodic
   \item Lower boundary conditions: no-slip and impermeability conditions for velocity, surface-flux condition for buoyancy
-  \item Upper boundary conditions: no-slip and impermeability conditions for velocity, zero-flux condition for buoyancy
+  \item Upper boundary conditions: free-slip conditions for velocity, zero-gradient condition for buoyancy
 \end{itemize}
 
 \subsection{Flow description and simulation results}


### PR DESCRIPTION
We inadvertently copied-and-pasted the wrong settings for the upper boundary condition of the katabatic experiments - it said no-slip, zero-flux when we meant free-slip, zero-gradient.